### PR TITLE
Fix command used to run extractor on Mac OS

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ You must pass in paths to Celeste .data files as arguments in order to convert t
 
 ```
 cd ~/Downloads/CelesteExtractor/CelesteExtractor
-dotnet run `find ~/Library/Application\ Support/Steam/steamapps/common/Celeste/Celeste.app/Contents/MacOS/Content/Graphics/Atlases -type f -name "*.data"`
+find ~/Library/Application\ Support/Steam/steamapps/common/Celeste/Celeste.app/Contents/Resources/Content/Graphics/Atlases -type f -name "*.data" | tr '\n' '\0' | xargs -0 dotnet run
 ```
 
 Or, on Windows with PowerShell try something like:


### PR DESCRIPTION
On MacOS 10.14.5, bash version 5.0.17(1), the command 
```
dotnet run `find ~/Library/Application\ Support/Steam/steamapps/common/Celeste/Celeste.app/Contents/MacOS/Content/Graphics/Atlases -type f -name "*.data"`
``` 
from the README does not work, due to the spaces in the filenames from the `find` not being properly escaped. The version in the pull request fixes this, instead using `xargs` to delineate the arguments. This has been tested to work on my computer, but I cannot guarantee it will work on other setups.